### PR TITLE
Set local mode env variable 

### DIFF
--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -37,7 +37,7 @@ misp_key = mispkey
 misp_domain = mispurl
 misp_verifycert = False
 
-if(not local_mode):
+if(not bool(local_mode)):
     misp_verifycert = True
 
 # MISP Event filters

--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -2,6 +2,8 @@ import os
 mispkey=os.getenv('mispkey')
 mispurl=os.getenv('mispurl')
 
+local_mode=os.getenv('local_mode')
+
 #####################
 # Microsoft Section #
 #####################
@@ -34,6 +36,9 @@ ms_action = 'alert'                     # action
 misp_key = mispkey
 misp_domain = mispurl
 misp_verifycert = False
+
+if(not local_mode):
+    misp_verifycert = True
 
 # MISP Event filters
 misp_event_filters = {

--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -2,7 +2,7 @@ import os
 mispkey=os.getenv('mispkey')
 mispurl=os.getenv('mispurl')
 
-local_mode=os.getenv('local_mode')
+local_mode=os.getenv('local_mode', 'False')
 
 #####################
 # Microsoft Section #

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Set `misp_key` to your MISP API key and `misp_domain` to the URL of your MISP se
 ```
 misp_key = '<misp_api_key>'
 misp_domain = '<misp_url>'
-misp_verifycert = False
+misp_verifycert = False (by default this is False, however this is determined by an environment variable set "local_mode", see see config.py
 ```
 
 The dictionary `misp_event_filters` defines which filters you want to pass on to MISP. This applies to both Graph API and Upload Indictors API. The suggested settings are


### PR DESCRIPTION
This setting is useful for the example provided here, determining if the MISP cert should be trusted or not, but can be extended beyond this in the future to check if Key Vault for example should be used.