### PR TITLE
Updated key vault guidance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
 # Key vault section
-keyVaultName = "misp-keys"
+# Key Vault name must be a globally unique DNS name
+keyVaultName = "<unique-name>"
 KVUri = f"https://{keyVaultName}.vault.azure.net"
 
 # Log in with the virtual machines managed identity

--- a/config.py.default
+++ b/config.py.default
@@ -4,7 +4,8 @@
 #from azure.identity import DefaultAzureCredential
 
 # Key vault section
-#keyVaultName = "misp-keys"
+# Key Vault name must be a globally unique DNS name
+keyVaultName = "<unique-name>"
 #KVUri = f"https://{keyVaultName}.vault.azure.net"
 
 # Log in with the virtual machines managed identity


### PR DESCRIPTION
Key Vault name needs to be a globally unique DNS name on the ".azurewebsites.net" domain

Happy to also just gen a unique GUID, so "ghtyf-1234-gf-misp-keys" or something like that?