### PR TITLE
[Security improvement] - Prefer Azure Key Vault over hard-coding config values

### DIFF
--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -43,6 +43,7 @@ if not len(keyVaultName) == 0:
     mispkey = retrieved_mispkey.value
     ms_auth['client_secret'] = retrieved_clientsecret
 
+print('key_vault_name env variable not set, falling back to env variable for config values....')
 mispkey=os.getenv('mispkey')
 
 #####################

--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -1,22 +1,53 @@
 import os
-mispkey=os.getenv('mispkey')
+
+from azure.keyvault.secrets import SecretClient
+from azure.identity import DefaultAzureCredential
+
+mispkey = ''
 mispurl=os.getenv('mispurl')
 
 local_mode=os.getenv('local_mode', 'False')
+keyVaultName=os.getenv('key_vault_name', '')
+
+tenant_id=os.getenv('tenant_id', '')
+workspace_id=os.getenv('workspace_id', '')
+client_id=os.getenv('client_id', '')
+client_secret=os.getenv('client_secret', '')
+
+# MS API settings
+ms_auth = {
+    'tenant': tenant_id,
+    'client_id': client_id,
+    'client_secret': client_secret,
+    'scope': 'https://management.azure.com/.default',
+    'graph_api': False,
+    'workspace_id': workspace_id
+}
+
+## If Azure Key Vault name variable is set, use it for secret values
+if not len(keyVaultName) == 0:
+    # Key vault section
+    # Key Vault name must be a globally unique DNS name
+    
+    KVUri = f"https://{keyVaultName}.vault.azure.net"
+    
+    # Log in with the virtual machines managed identity
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=KVUri, credential=credential)
+    
+    # Retrieve values from KV (client secret, MISP-key most importantly)
+    retrieved_mispkey = client.get_secret('MISP-Key')
+    retrieved_clientsecret = client.get_secret('ClientSecret')
+    
+    # Set values with 
+    mispkey = retrieved_mispkey.value
+    ms_auth['client_secret'] = retrieved_clientsecret
+
+mispkey=os.getenv('mispkey')
 
 #####################
 # Microsoft Section #
 #####################
-
-# MS API settings
-ms_auth = {
-    'tenant': '',
-    'client_id': '',
-    'client_secret': '',
-    'scope': 'https://management.azure.com/.default',
-    'graph_api': False,
-    'workspace_id': ''
-}
 
 ms_max_indicators_request = 100     # Throttle max: 100 indicators per request
 ms_max_requests_minute = 100        # Throttle max: 100 requests per minute
@@ -69,8 +100,8 @@ default_confidence = 50
 days_to_expire = 30
 days_to_expire_start = "current_date" # Upload Indicators API only. Start counting from "valid_from" | "current_date" ; 
 days_to_expire_mapping = {          # Upload indicators API only. Mapping for expiration of specific indicator types
-                    "ipv4-addr": 150,
-                    "ipv6-addr": 150,
-                    "domain-name": 300,
-                    "url": 400
-                }
+                        "ipv4-addr": 150,
+                        "ipv6-addr": 150,
+                        "domain-name": 300,
+                        "url": 400
+                    }

--- a/README.md
+++ b/README.md
@@ -185,7 +185,15 @@ You then need **Python3**, a Python virtual environment and PyMISP.
 
 ## Configuration
 
-The configuration is in `config.py`. 
+The configuration is handled in the `config.py` file.
+
+By default the config.py will look to use Azure Key Vault if configured, if you set a **"key_vault_name"** value in your environment variables, to the name of the Azure Key Vault you have deployed, this will be the default store for all secret and configuration values.
+
+If you do not set the above value, the config.py will then fall-back to using environment variables and lastly, values directly written inside of the config.py file.
+
+[Guidance for assigning a Management Service Indeitity to Function App](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp)
+
+[Assigning your function app permissions to Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/assign-access-policy?tabs=azure-portal) - **NOTE** - you only need to assign "Secret GET" permission to your function app Management Service Identity.
 
 ### Microsoft settings
 


### PR DESCRIPTION
This change gives the implementor the option to use Azure Key Vault as the secret store for secret values such as the Azure Service Principal client secret and the misp_key.

If the user does not want to read from Azure Key Vault or implement it as such, the solution will fall back to reading values from environment variable, which in the context of Azure Functions means at least they are encrypted at rest and in transit.

Changing the values should the implementor choose to do so, will also now not require a code change.

For Key Vault to be used, an MSI must be enabled on the Function - https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp

To grant the newly created MSI relevant Azure Key Vault permission via an "Azure Key Vault Access Policy" this guide can be referenced - https://learn.microsoft.com/en-us/azure/key-vault/general/assign-access-policy?tabs=azure-portal