### PR TITLE
Use PyMISP instead of ExpandedPyMISP

### DIFF
--- a/AzureFunction/MISP2Sentinel/__init__.py
+++ b/AzureFunction/MISP2Sentinel/__init__.py
@@ -1,5 +1,4 @@
 from pymisp import PyMISP
-from pymisp import ExpandedPyMISP
 import MISP2Sentinel.config as config
 from collections import defaultdict
 from MISP2Sentinel.RequestManager import RequestManager
@@ -23,7 +22,7 @@ if config.misp_verifycert is False:
 
 def _get_misp_events_stix():
     logging.info(f"Using the following values for MISP API call: domain: {config.misp_domain}, misp API key: {config.misp_key[:-5] + '*' + '*' + '*' + '*' + '*'}...")
-    misp = ExpandedPyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
+    misp = PyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
     result_set = []
     logging.debug("Query MISP for events.")
     remaining_misp_pages = True

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Almost all MISP objects are translated, but there can be situations where the MI
 This little Python snippet can help you find out if elements are correctly translated. Adjust `misp_event_filters` to query only for the event with a non-default object.
 
 ```
-misp = ExpandedPyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
+misp = PyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
 misp_page = 1
 config.misp_event_limit_per_page = 100
 result = misp.search(controller='events', return_format='json', **config.misp_event_filters, limit=config.misp_event_limit_per_page, page=misp_page)

--- a/script.py
+++ b/script.py
@@ -20,7 +20,7 @@ if config.misp_verifycert is False:
 
 
 def _get_events():
-    misp = ExpandedPyMISP(config.misp_domain, config.misp_key, config.misp_verifycert)
+    misp = PyMISP(config.misp_domain, config.misp_key, config.misp_verifycert)
     if len(config.misp_event_filters) == 0:
         return [event['Event'] for event in misp.search(controller='events', return_format='json')]
     events_for_each_filter = [
@@ -76,7 +76,7 @@ def _handle_tlp_level(parsed_event):
 
 
 def _get_misp_events_stix():
-    misp = ExpandedPyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
+    misp = PyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
     result_set = []
     logger.debug("Query MISP for events.")
     remaining_misp_pages = True


### PR DESCRIPTION
- ExpandedPyMISP has superseded PyMISP and has been renamed
- The alias ExpandedPyMISP throws deprecation errors at this point

- blind change, still needs to see if it completely fixes the issue, as @ufosmuggler pointed out in the chat, from pymisp import * might still lead to deprecation warnings om script.py

- See more about the discussion on MISP/Support on gitter