### PR TITLE
Support specifying the MISP filters in an env var

### DIFF
--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -14,7 +14,6 @@ tenant_id=os.getenv('tenant_id', '')
 workspace_id=os.getenv('workspace_id', '')
 client_id=os.getenv('client_id', '')
 client_secret=os.getenv('client_secret', '')
-misp_event_filter_timestamp=os.getenv('misp_event_filter_timestamp', '14d')
 
 # MS API settings
 ms_auth = {

--- a/AzureFunction/MISP2Sentinel/config.py
+++ b/AzureFunction/MISP2Sentinel/config.py
@@ -1,4 +1,5 @@
 import os
+import json 
 
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
@@ -13,6 +14,7 @@ tenant_id=os.getenv('tenant_id', '')
 workspace_id=os.getenv('workspace_id', '')
 client_id=os.getenv('client_id', '')
 client_secret=os.getenv('client_secret', '')
+misp_event_filter_timestamp=os.getenv('misp_event_filter_timestamp', '14d')
 
 # MS API settings
 ms_auth = {
@@ -73,11 +75,19 @@ if(not bool(local_mode)):
     misp_verifycert = True
 
 # MISP Event filters
-misp_event_filters = {
-    "timestamp": "14d",
-    "enforceWarninglist": True,
-    "includeEventTags": True
-}
+if os.getenv('misp_event_filters', None):
+    misp_event_filters_raw = os.getenv('misp_event_filters')
+    try:
+        misp_event_filters = json.loads(misp_event_filters_raw)
+    except json.JSONDecodeError:
+        raise RuntimeError("Error parsing misp_event_filters. Make sure the content is a valid JSON object.")
+else:
+    misp_event_filters = {
+        "published": 1,
+        "publish_timestamp": "14d",
+        "enforceWarninglist": True,
+        "includeEventTags": True
+    }
 
 # MISP pagination settings
 misp_event_limit_per_page = 100      # Limit memory use when querying MISP for STIX packages

--- a/AzureFunction/README.MD
+++ b/AzureFunction/README.MD
@@ -51,7 +51,7 @@ Full instructions in [INSTALL.md](../docs/INSTALL.MD)
 11.  Add a "New application setting" (env variable) `timerTriggerSchedule` and set it to run. If you're running against multiple tenants with a big filter, set it to run once every two hours or so. 
    * The `timerTriggerSchedule` takes a cron expression. For more information, see [Timer trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=python-v2%2Cin-process&pivots=programming-language-python).
    * Run once every two hours cron expression: `0 */2 * * *`
-
+12. Optionally add a "New application setting" (env variable) `misp_event_filters` and set it to a valid JSON object representing the filters to use when querying the MISP server (as per [MISP Settings](https://github.com/cudeso/misp2sentinel?tab=readme-ov-file#misp-settings)).
 
 #### Multi-tenant support
 


### PR DESCRIPTION
While getting this up and running in an azure function app on a Flex Consumption Plan, I found it very useful to be able to change the MISP filter values without having to republish the app. This small PR adds support for that.