### PR TITLE
Update RequestObject.py to fix Issue #120 - 'STIXdatetime' object is not subscriptable

### DIFF
--- a/AzureFunction/MISP2Sentinel/RequestObject.py
+++ b/AzureFunction/MISP2Sentinel/RequestObject.py
@@ -135,7 +135,7 @@ class RequestObject_Indicator:
                 if config.days_to_expire_start.lower().strip() == "current_date":       # We start counting from current date
                     date_object = datetime.now() + timedelta(days=days_to_expire)
                 elif config.days_to_expire_start.lower().strip() == "valid_from":       # Start counting from valid_from
-                    date_object = datetime.fromisoformat(self.valid_from[:-1]) + timedelta(days=days_to_expire)
+                    date_object = datetime.fromisoformat(repr(self.valid_from).strip("'")[:-1]) + timedelta(days=days_to_expire)
                 if date_object:
                     self.valid_until = date_object.strftime("%Y-%m-%dT%H:%M:%SZ")
 


### PR DESCRIPTION
Attempts to fix Issue #120: Error when processing data from MISP 'STIXdatetime' object is not subscriptable

by calling repr() method of stix2.utils.STIXdatetime object on Line 138 to put datetime string in expected format.