### PR TITLE
Add MISP decaying model support and document decay score configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,37 @@ default_confidence = 50
 
 Sets the default STIX confidence value (0-100) for indicators. This can be overridden per indicator through MISP tags that use the `misp-confidence` taxonomy.
 
+#### MISP Decay Model integration
+
+If your MISP instance uses the [Decay Model](https://www.misp-project.org/2019/09/12/Decaying-Of-Indicators.html/), the connector can request attribute decay scores for a specific MISP decaying model, use the returned score as the confidence value sent to Sentinel, and optionally exclude indicators whose score has fallen below a threshold.
+
+```python
+misp_decaying_model = 1                     # MISP decaying model ID used for attribute decay scores
+misp_decaying_score_as_confidence = False   # Use the MISP decay score as the Sentinel confidence value
+misp_decaying_score_threshold = None        # Set to None to disable decay score-based filtering
+                                            # Set to a value >= 0 to exclude indicators with a decay score <= this threshold
+                                            # Example: 10 excludes indicators with a decay score of 10 or lower
+```
+- `misp_decaying_model`: MISP decaying model ID used when requesting attribute decay scores. The default is `1`. Available model IDs can be listed in MISP under `/decayingModel/index`.
+- `misp_decaying_score_as_confidence`: When set to `True`, the MISP decay score of an attribute is used as the STIX confidence value (0-100) sent to Sentinel.
+- `misp_decaying_score_threshold`: Attributes with a decay score less than or equal to this value are excluded from upload. Set it to `None` (default) to disable this filtering entirely. Set it to `0` to exclude indicators whose decay score has reached zero (fully decayed). A typical starting value is `10`.
+
+> **Note:** The default decaying model ID is `1`. Decaying model IDs are instance-specific, so if your MISP instance uses another model you should update `misp_decaying_model` accordingly. You can list available models in MISP at `/decayingModel/index`.
+
+**Priority order for confidence (highest to lowest):**
+
+| Priority | Source | Condition |
+|---|---|---|
+| 1 | MISP decay score | `misp_decaying_score_as_confidence = True` and a score is available |
+| 2 | MISP `misp-confidence` taxonomy tag | Tag present and no decay score applied |
+| 3 | `default_confidence` | Fallback when neither of the above applies |
+
+> **Note:** When `misp_decaying_score_as_confidence` is set to `True`, the decay score takes precedence over any `misp-confidence` taxonomy tag, if a score is available. If no decay score is returned for an attribute, the script falls back to the confidence derived from MISP tags, or to `default_confidence` if no confidence tag is present.
+>
+> **Note:** Threshold filtering only applies when a decay score is available. Attributes without a decay score are not excluded by `misp_decaying_score_threshold`.
+>
+> **Note:** If MISP returns the same attribute UUID multiple times, the script keeps the highest decay score found for that UUID.
+
 ### Other settings
 
 ```python
@@ -348,6 +379,7 @@ To get the most out of the Sentinel integration, enable the following MISP taxon
 - [MISP taxonomy](https://www.misp-project.org/taxonomies.html#_misp) (used for confidence levels)
 - [sentinel-threattype](https://www.misp-project.org/taxonomies.html#_sentinel_threattype) (mapped to STIX `indicator_types`)
 - [kill-chain](https://www.misp-project.org/taxonomies.html#_kill_chain) (mapped to STIX kill chain phases)
+- [Decay Model](https://www.misp-project.org/2019/09/12/Decaying-Of-Indicators.html/) (optional — used for decay-score-based confidence and filtering)
 
 These taxonomies are not required for the integration to work, but they add useful context for analysts working with the indicators in Sentinel.
 
@@ -356,6 +388,7 @@ These taxonomies are not required for the integration to work, but they add usef
 #### Confidence level
 
 The default confidence value (set in `default_confidence`) can be overridden per indicator using the MISP confidence taxonomy. The tag is translated to a numerical value as defined by `MISP_CONFIDENCE` in `constants.py`.
+If `misp_decaying_score_as_confidence` is enabled and a decay score is available for the attribute, the decay score overrides the confidence derived from the taxonomy tag.
 
 ![docs/Taxonomies_-_MISP.png](docs/Taxonomies_-_MISP.png)
 
@@ -437,6 +470,23 @@ Check the following:
 - Is the `to_ids` flag set to `True` on the attribute?
 - Is the attribute type one of the supported types (listed in `UPLOAD_INDICATOR_MISP_ACCEPTED_TYPES` in `constants.py`)?
 - Has the `valid_until` date already passed? Expired indicators are skipped.
+
+### My indicators are being skipped unexpectedly
+
+If indicators that have `to_ids = True` are not being uploaded, check whether `misp_decaying_score_threshold` is set to a value other than `None`. Attributes with a decay score less than or equal to this threshold are excluded from the upload. Set it to `None` to disable this filtering entirely, or lower the threshold value.
+
+Also verify that `misp_decaying_model` matches a valid decaying model ID on your MISP instance. The default is `1`, but another model may be more appropriate depending on your configuration.
+
+You can enable `verbose_log = True` to see which indicators are being skipped and why.
+
+### My indicators all have the same confidence value
+
+If all indicators show `default_confidence` in Sentinel despite having decay scores in MISP, check the following:
+
+- Is `misp_decaying_score_as_confidence` set to `True` in `config.py`?
+- Does the MISP API response include a `decay_score` entry for the attributes, with a usable `score` value?
+- Is the Decay Model enabled in MISP and applied to the events you are synchronising?
+- Is `misp_decaying_model` set to a valid decaying model ID for your MISP instance?
 
 ### Error: KeyError: 'access_token'
 

--- a/config.py.default
+++ b/config.py.default
@@ -67,6 +67,14 @@ ignore_localtags = True
 
 default_confidence = 50
 
+misp_decaying_model = 1                     # MISP decaying model ID used for attribute decay scores. Available id models are visible in MISP at https://__IP__/decayingModel/index
+misp_decaying_score_as_confidence = False   # Use the MISP decay score as the Sentinel confidence value
+misp_decaying_score_threshold = None        # Set to None to disable decay score-based filtering
+                                            # Set to a value >= 0 to exclude indicators with a decay score <= this threshold
+                                            # Example: 10 excludes indicators with a decay score of 10 or lower
+
+
+
 days_to_expire = 50
 days_to_expire_start = "valid_from" # Start counting from "valid_from" or "current_date"
 days_to_expire_mapping = {          # Per-type overrides for days_to_expire

--- a/script.py
+++ b/script.py
@@ -319,41 +319,54 @@ def delete_outdated_indicators():
 def init_decaying_cache(misp):
     logger.info("Querying MISP for attribute decay scores")
 
-    results = misp.search(controller='attributes',
-                          to_ids=1,
-                          decayingModel=str(config.misp_decaying_model),
-                          includeDecayScore=True,
-                          type_attribute=list(UPLOAD_INDICATOR_MISP_ACCEPTED_TYPES),
-                          return_format='json')
-
-    if isinstance(results, list):
-        attributes = results
-    elif isinstance(results, dict):
-        attributes = results.get("Attribute") or results.get("response", {}).get("Attribute", [])
-    else:
-        attributes = []
-
     decaying_cache = {}
+    misp_page = 1
+    remaining_misp_pages = True
+    page_size = 10000
 
-    for attribute in attributes:
-        attribute_uuid = attribute.get("uuid")
-        if not attribute_uuid:
+    while remaining_misp_pages:
+        results = misp.search(
+            controller='attributes',
+            to_ids=1,
+            decayingModel=str(config.misp_decaying_model),
+            includeDecayScore=True,
+            type_attribute=list(UPLOAD_INDICATOR_MISP_ACCEPTED_TYPES),
+            return_format='json',
+            limit=page_size,
+            page=misp_page
+        )
+
+        if isinstance(results, list):
+            attributes = results
+        elif isinstance(results, dict):
+            attributes = results.get("Attribute") or results.get("response", {}).get("Attribute", [])
+        else:
+            attributes = []
+
+        if not attributes:
+            remaining_misp_pages = False
             continue
 
-        score = None
-        try:
-            score = float(attribute.get("decay_score", [{}])[0].get("score"))
-        except Exception:
-            pass
+        for attribute in attributes:
+            attribute_uuid = attribute.get("uuid")
+            if not attribute_uuid:
+                continue
 
-        # If the same attribute UUID is returned multiple times, we keep
-        # the highest decay score found for that UUID.
-        current_score = decaying_cache.get(attribute_uuid)
-        if current_score is None or (score is not None and score > current_score):
-            decaying_cache[attribute_uuid] = score
+            score = None
+            try:
+                score = float(attribute.get("decay_score", [{}])[0].get("score"))
+            except Exception:
+                pass
+
+            current_score = decaying_cache.get(attribute_uuid)
+            if current_score is None or (score is not None and score > current_score):
+                decaying_cache[attribute_uuid] = score
+
+        remaining_misp_pages = len(attributes) == page_size
+        misp_page += 1
 
     logger.info("Initialized MISP decaying cache with {} unique attribute UUIDs".format(len(decaying_cache)))
-    return decaying_cache    
+    return decaying_cache
 
 
 def get_decaying_score(attribute_uuid, decaying_cache):

--- a/script.py
+++ b/script.py
@@ -316,6 +316,52 @@ def delete_outdated_indicators():
     return total_deleted, total_failed
 
 
+def init_decaying_cache(misp):
+    logger.info("Querying MISP for attribute decay scores")
+
+    results = misp.search(controller='attributes',
+                          to_ids=1,
+                          decayingModel=str(config.misp_decaying_model),
+                          includeDecayScore=True,
+                          type_attribute=list(UPLOAD_INDICATOR_MISP_ACCEPTED_TYPES),
+                          return_format='json')
+
+    if isinstance(results, list):
+        attributes = results
+    elif isinstance(results, dict):
+        attributes = results.get("Attribute") or results.get("response", {}).get("Attribute", [])
+    else:
+        attributes = []
+
+    decaying_cache = {}
+
+    for attribute in attributes:
+        attribute_uuid = attribute.get("uuid")
+        if not attribute_uuid:
+            continue
+
+        score = None
+        try:
+            score = float(attribute.get("decay_score", [{}])[0].get("score"))
+        except Exception:
+            pass
+
+        # If the same attribute UUID is returned multiple times, we keep
+        # the highest decay score found for that UUID.
+        current_score = decaying_cache.get(attribute_uuid)
+        if current_score is None or (score is not None and score > current_score):
+            decaying_cache[attribute_uuid] = score
+
+    logger.info("Initialized MISP decaying cache with {} unique attribute UUIDs".format(len(decaying_cache)))
+    return decaying_cache    
+
+
+def get_decaying_score(attribute_uuid, decaying_cache):
+    if not decaying_cache:
+        return None
+    return decaying_cache.get(attribute_uuid, None)
+
+
 def get_misp_events_upload_indicators(event_uuid=None):
     misp = PyMISP(config.misp_domain, config.misp_key, config.misp_verifycert, False)
     
@@ -324,6 +370,12 @@ def get_misp_events_upload_indicators(event_uuid=None):
         logger.info("Using event UUID filter: {}".format(event_uuid))
     else:
         misp_event_filters = config.misp_event_filters
+
+    use_decaying_score = False
+    decaying_cache = None
+    if config.misp_decaying_score_as_confidence or config.misp_decaying_score_threshold is not None:
+        use_decaying_score = True
+        decaying_cache = init_decaying_cache(misp)
     
     logger.debug("Query MISP for events")
     remaining_misp_pages = True
@@ -368,7 +420,23 @@ def get_misp_events_upload_indicators(event_uuid=None):
                             if element.get("to_ids", False) and \
                                         element.get("type", "") in UPLOAD_INDICATOR_MISP_ACCEPTED_TYPES:
 
+                                decaying_score = None
+                                if use_decaying_score:
+                                    decaying_score = get_decaying_score(element.get("uuid", ""), decaying_cache)
+                                    if (
+                                        config.misp_decaying_score_threshold is not None
+                                        and decaying_score is not None
+                                        and decaying_score <= config.misp_decaying_score_threshold
+                                    ):
+                                        if config.verbose_log:
+                                                logger.debug("Skipping indicator {} due to low decay score ({})".format(
+                                                    element.get("value"), decaying_score
+                                                ))
+                                        continue
+
                                 misp_indicator = RequestObject_Indicator(element, misp_event, logger)
+                                if config.misp_decaying_score_as_confidence and decaying_score is not None:
+                                    misp_indicator.confidence = max(0, min(100, int(round(decaying_score))))
                                 #print(misp_indicator._get_dict())
                                 if misp_indicator.valid_until:
                                     try:
@@ -403,6 +471,8 @@ def get_misp_events_upload_indicators(event_uuid=None):
                                         if not skip_to_sentinel:
                                             if config.verbose_log:
                                                 logger.debug("Add {} to list of indicators to upload".format(misp_indicator.pattern))
+                                                if config.misp_decaying_score_as_confidence:
+                                                    logger.debug("Confidence from decaying score: {}".format(misp_indicator.confidence))
                                             result_set.append(misp_indicator._get_dict())
                                             indicator_values.append(element["value"])
                                     except exceptions.STIXError as e:
@@ -473,7 +543,12 @@ def init_configuration():
         config.timeframe_toids_change = "1d"
     if not hasattr(config, "ms_delete_api_version"):
         config.ms_delete_api_version = "2025-09-01"
-
+    if not hasattr(config, "misp_decaying_score_as_confidence"):
+        config.misp_decaying_score_as_confidence = False
+    if not hasattr(config, "misp_decaying_score_threshold"):
+        config.misp_decaying_score_threshold = None
+    if not hasattr(config, "misp_decaying_model"):
+        config.misp_decaying_model = 1
 
 
 global _build_logger


### PR DESCRIPTION
Hello @cudeso ,

Here is some information about the Decaying Model integration.

When the decaying-related settings are enabled, the script initializes a cache containing only `attribute_uuid -> decay_score`. To build this cache, it queries MISP once to retrieve all relevant attributes and their decay scores. In my lab, this step takes about 1 minutes.

After that, this dictionary is used to retrieve the decay score for each attribute during processing. This avoids making direct API calls for each individual attribute and saves a huge number of API requests.

The `misp_decaying_score_threshold` setting provides a practical equivalent to `excludeDecayed`, allowing the script to skip low-value / fully decayed indicators before uploading them to Sentinel. In my lab, this removes a significant number of IOCs from the upload set.

Please take a look and let me know if you have any feedback.

Closes #93

Guillaume